### PR TITLE
Setting series and units as non-disaggregations

### DIFF
--- a/config_data.yml
+++ b/config_data.yml
@@ -123,3 +123,9 @@ docs_intro: This is a list of examples of endpoints and output that are
 # This can be uncommented and updated so allow links to your indicator pages.
 # The URL here should have [id] instead of the indicator ID.
 #docs_indicator_url: https://my-github-org/my-site-repository/[id]
+
+# 
+indicator_options:
+  non_disaggregation_columns:
+    - SGD Series
+    - Unit of measure


### PR DESCRIPTION
I have set 

indicator_options:
  non_disaggregation_columns: 

to include

SDG Series 
and 
Unit of measure